### PR TITLE
Include the GCAM version in the results of listScenariosInDB

### DIFF
--- a/gcam_reader/querymi.py
+++ b/gcam_reader/querymi.py
@@ -253,13 +253,14 @@ class LocalDBConn:
         To run a query users typically need to know the names of the scenarios in the
         database.  If they are the ones to generate the data in the first place they
         may already know this information.  Otherwise they could use this method to find
-        out.  The result of this call will be a table with columns name, date, and fqName
+        out.  The result of this call will be a table with columns name, date, version, and fqName
         The name and date are exactly as specified in the datbase. The fqName is the fully
         qualified scenario name which a user could use in the scenarios argument of runQuery
-        if they need to disambiguate scenario names.
+        if they need to disambiguate scenario names. We also include the GCAM version tag that was
+        used to generate the scenario.
         """
 
-        querystr = "let $scns := collection()/scenario return document{ element csv { for $scn in $scns return element record { element name  { text { $scn/@name } }, element date { text { $scn/@date } } } } }"
+        querystr = "let $scns := collection()/scenario return document{ element csv { for $scn in $scns return element record { element name  { text { $scn/@name } }, element date { text { $scn/@date } }, element version { text{ $scn/model-version/text() } } } } }"
         cmd =  [
             "java",
             "-cp", self.miclasspath,
@@ -396,17 +397,18 @@ class RemoteDBConn:
         To run a query users typically need to know the names of the scenarios in the
         database.  If they are the ones to generate the data in the first place they
         may already know this information.  Otherwise they could use this method to find
-        out.  The result of this call will be a table with columns name, date, and fqName
+        out.  The result of this call will be a table with columns name, date, version, and fqName
         The name and date are exactly as specified in the datbase. The fqName is the fully
         qualified scenario name which a user could use in the scenarios argument of runQuery
-        if they need to disambiguate scenario names.
+        if they need to disambiguate scenario names.  We also include the GCAM version tag that
+        was used to generate the scenario.
         """
         from requests import post
 
         restquery = str.join("\n", [
                 '<rest:query xmlns:rest="http://basex.org/rest">',
                 '<rest:text><![CDATA[',
-                'let $scns := collection()/scenario return document{ element csv { for $scn in $scns return element record { element name  { text { $scn/@name } }, element date { text { $scn/@date } } } } }',
+                'let $scns := collection()/scenario return document{ element csv { for $scn in $scns return element record { element name  { text { $scn/@name } }, element date { text { $scn/@date } }, element version { text{ $scn/model-version/text() } } } } }',
                 ']]></rest:text>',
                 '<rest:parameter name="method" value="csv"/>',
                 '<rest:parameter name="media-type" value="text/csv"/>',

--- a/gcam_reader/querymi.py
+++ b/gcam_reader/querymi.py
@@ -257,7 +257,7 @@ class LocalDBConn:
         The name and date are exactly as specified in the datbase. The fqName is the fully
         qualified scenario name which a user could use in the scenarios argument of runQuery
         if they need to disambiguate scenario names. We also include the GCAM version tag that was
-        used to generate the scenario.
+        used to generate the scenario in the format: ver_<major>.<minor>_r<git describe value>
         """
 
         querystr = "let $scns := collection()/scenario return document{ element csv { for $scn in $scns return element record { element name  { text { $scn/@name } }, element date { text { $scn/@date } }, element version { text{ $scn/model-version/text() } } } } }"
@@ -401,7 +401,7 @@ class RemoteDBConn:
         The name and date are exactly as specified in the datbase. The fqName is the fully
         qualified scenario name which a user could use in the scenarios argument of runQuery
         if they need to disambiguate scenario names.  We also include the GCAM version tag that
-        was used to generate the scenario.
+        was used to generate the scenario in the format: ver_<major>.<minor>_r<git describe value>
         """
         from requests import post
 


### PR DESCRIPTION
It will add a column to the result of `listScenariosInDB` such as:
```
> listScenariosInDB(conn)
# A tibble: 9 x 4
  name                          date                    version           fqName                                             
  <chr>                         <chr>                   <chr>             <chr>                                              
1 GCAM-USA_Disp_NewSeg          2018-1-8T12:03:50-04:00 ver_4.4_rgcam-v4… GCAM-USA_Disp_NewSeg 2018-1-8T12:03:50-04:00       
2 MonSeg_FitInvestSeg           2018-17-8T08:41:20-04:… ver_4.4_rgcam-v4… MonSeg_FitInvestSeg 2018-17-8T08:41:20-04:00       
3 GCAM-USA_MonSeg_FitInvestSeg  2018-17-8T11:23:43-04:… ver_4.4_rgcam-v4… GCAM-USA_MonSeg_FitInvestSeg 2018-17-8T11:23:43-04…
4 GCAM-USA_MonSeg_FitInvestSeg  2018-17-8T12:38:27-04:… ver_4.4_rgcam-v4… GCAM-USA_MonSeg_FitInvestSeg 2018-17-8T12:38:27-04…
5 GCAM-USA_MonSeg_FitInvestSeg… 2018-17-8T14:27:51-04:… ver_4.4_rgcam-v4… GCAM-USA_MonSeg_FitInvestSeg_Sw 2018-17-8T14:27:51…
6 GCAM-USA_MonSeg_FitInvestSeg… 2018-17-8T22:34:15+20:… ver_4.4_rgcam-v4… GCAM-USA_MonSeg_FitInvestSeg_Sw 2018-17-8T22:34:15…
7 GCAM-USA_MonSeg_FitInvestSeg… 2018-19-8T08:17:45-04:… ver_4.4_rgcam-v4… GCAM-USA_MonSeg_FitInvestSeg_Sw 2018-19-8T08:17:45…
8 GCAM-USA_MonSeg_FitInvestSeg… 2018-20-8T11:39:29-04:… ver_4.4_rgcam-v4… GCAM-USA_MonSeg_FitInvestSeg_Sw 2018-20-8T11:39:29…
9 GCAM-USA_MonSeg_FitInvestSeg… 2019-10-1T14:26:54-05:… ver_4.4_rgcam-v4… GCAM-USA_MonSeg_FitInvestSeg_Sw 2019-10-1T14:26:54…
```