### PR TITLE
Require >= Python 3.5

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,0 @@
-requests
-lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.18.4
+pandas>=0.20
+lxml>=4.2.1

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,42 @@
+import sys
 from setuptools import setup
+
+
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
+# [0] major version, [1] minor, [2] mirco, [3] releaselevel, [4] serial
+reader_info = sys.version_info
+
+# account for version dependency for subprocess
+if (reader_info[0] == 3) and (reader_info[1] >= 5):
+    pass
+
+elif (reader_info[0] == 3) and (reader_info[1] < 5):
+    msg = """DEPRECIATION:  gcam_reader will soon only support >= Python 3.5. Please upgrade
+             your Python version."""
+
+    requirements.append("subprocess.run>=0.0.8")
+
+    raise PendingDeprecationWarning(msg)
+
+elif (reader_info[0] == 2) and (reader_info[1] in (6, 7)):
+    msg = """DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020.
+             Please upgrade your Python as Python 2.7 won't be maintained after that date.
+             A future version of pip will drop support for Python 2.7.
+             gcam_reader will soon only support >= Python 3.5. Please upgrade
+             your Python version."""
+
+    raise PendingDeprecationWarning(msg)
+
+else:
+    msg = """DEPRECATION: Your Python version {}.{} is depreciated Python 2.7 will reach the end of its life on January 1st, 2020.
+             Please upgrade your Python as Python 2.7 won't be maintained after that date.
+             A future version of pip will drop support for Python 2.7.
+             gcam_reader will soon only support >= Python 3.5. Please upgrade
+             your Python version.""".format(reader_info[0], reader_info[1])
+
+    raise DeprecationWarning(msg)
 
 setup(
     name="gcam_reader",
@@ -8,12 +46,7 @@ setup(
     author="Robert Link",
     author_email="robert.link@pnnl.gov",
     packages=["gcam_reader"],
-    install_requires=[
-        "requests>=2.18.4",
-        "pandas>=0.20",
-        "lxml>=4.2.1",
-    ],
+    install_requires=requirements,
     include_package_data=True,
     zip_safe=False
     )
-

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,10 @@ with open('requirements.txt') as f:
 
 # [0] major version, [1] minor, [2] mirco, [3] releaselevel, [4] serial
 reader_info = sys.version_info
-print(reader_info)
 
 # account for version dependency for subprocess
 if (reader_info[0] == 3) and (reader_info[1] >= 5):
     pass
-
-elif (reader_info[0] == 3) and (reader_info[1] < 5):
-    msg = """\nDEPRECIATION:  gcam_reader will soon only support >= Python 3.5. Please upgrade
-             your Python version.\n"""
 
 else:
     msg = """\nDEPRECATION: Your Python version {}.{} is depreciated due to Python 2.7 reaching the end of its life on 

--- a/setup.py
+++ b/setup.py
@@ -7,34 +7,21 @@ with open('requirements.txt') as f:
 
 # [0] major version, [1] minor, [2] mirco, [3] releaselevel, [4] serial
 reader_info = sys.version_info
+print(reader_info)
 
 # account for version dependency for subprocess
 if (reader_info[0] == 3) and (reader_info[1] >= 5):
     pass
 
 elif (reader_info[0] == 3) and (reader_info[1] < 5):
-    msg = """DEPRECIATION:  gcam_reader will soon only support >= Python 3.5. Please upgrade
-             your Python version."""
-
-    requirements.append("subprocess.run>=0.0.8")
-
-    raise PendingDeprecationWarning(msg)
-
-elif (reader_info[0] == 2) and (reader_info[1] in (6, 7)):
-    msg = """DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020.
-             Please upgrade your Python as Python 2.7 won't be maintained after that date.
-             A future version of pip will drop support for Python 2.7.
-             gcam_reader will soon only support >= Python 3.5. Please upgrade
-             your Python version."""
-
-    raise PendingDeprecationWarning(msg)
+    msg = """\nDEPRECIATION:  gcam_reader will soon only support >= Python 3.5. Please upgrade
+             your Python version.\n"""
 
 else:
-    msg = """DEPRECATION: Your Python version {}.{} is depreciated Python 2.7 will reach the end of its life on January 1st, 2020.
-             Please upgrade your Python as Python 2.7 won't be maintained after that date.
-             A future version of pip will drop support for Python 2.7.
-             gcam_reader will soon only support >= Python 3.5. Please upgrade
-             your Python version.""".format(reader_info[0], reader_info[1])
+    msg = """\nDEPRECATION: Your Python version {}.{} is depreciated due to Python 2.7 reaching the end of its life on 
+                January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date.
+                A future version of pip will drop support for Python 2.7.
+                \ngcam_reader will now only support >= Python 3.5. Please upgrade your Python version.\n""".format(reader_info[0], reader_info[1])
 
     raise DeprecationWarning(msg)
 


### PR DESCRIPTION
An issue was originally created to address `subprocess.run()` not existing in Python versions prior to v3.5.  I tested a retrofitting solution using a new dependency named `subprocess.run` that can be installed via `pip`.  This module was supposed to add the `run` class into `subprocess` and create compatibility for versions 2.6, 2.7, and 3.3.  However, I ran into the following issues:

- `pip` not able to satisfy the version requirements of `subprocess.run` when installing on Python 2.7.15

- conflicts with the original subprocess module

I also looked into backporting to `subprocess32` for Python 2 versions.  This would only help out with v2 and not v3.  At this point, I decided to simply require users to run `gcam_reader` on Python versions >= 3.5 to eliminate any future issues with compatibility with other models and tools in the GCAM model ecosystem.  This was already an unstated requirement of `gcam_reader` and will not change functionality for those who currently use it.  

For this PR:

- replaced `depends.txt` with `requirements.txt`

- now read in `requirements.txt` instead of having the dependencies hard-coded into `setup.py`

- raise `DepreciationWarning` for versions < 3.5

Resolves #1 